### PR TITLE
adds StackBlitz init config, changes badge

### DIFF
--- a/.stackblitzrc
+++ b/.stackblitzrc
@@ -1,0 +1,3 @@
+{
+  "startCommand": "npm run start"
+}

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 
 ## Demo
 
-[![StackBlitz Demo](https://user-images.githubusercontent.com/7531596/83507657-2424e180-a4c9-11ea-8e4f-b3f8e7d6b4c5.png)](https://stackblitz.com/github/wlucha/angular-starter)
+[![StackBlitz Demo](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/wlucha/angular-starter)
 
 ## Install / Development
 


### PR DESCRIPTION
Hey! I found that your project cannot be imported in StackBlitz: it hangs on `Compiling application & starting dev server` stage. Same problem is also mentioned in the issue https://github.com/wlucha/angular-starter/issues/29.

Here I added `.stackblitzrc` file, as described in [docs](https://developer.stackblitz.com/guides/integration/open-from-github), and I also decided to change the badge image in the `README.md` to the official one.

You can test how that works here: https://stackblitz.com/fork/github/spanic/angular-starter/tree/stackblitz_init_config_fix

<img width="1728" alt="Screenshot 2023-09-13 at 01 34 59" src="https://github.com/wlucha/angular-starter/assets/15694775/4f58f503-cdb9-404b-bc08-96928e20fab0">
